### PR TITLE
Sort stickies by like and created_by

### DIFF
--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -12,6 +12,6 @@ class Board < ActiveRecord::Base
   validates :title, presence: true, length: { maximum: 20 }
 
   def select_stickies(group)
-    stickies.select { |s| s.group == group.to_s }
+    stickies.order(like: :desc, created_at: :asc).select { |s| s.group == group.to_s }
   end
 end

--- a/spec/models/board_spec.rb
+++ b/spec/models/board_spec.rb
@@ -28,4 +28,41 @@ RSpec.describe Board, type: :model do
     before { board.title = "a" * 21 }
     it { should_not be_valid }
   end
+
+  describe "select stickies by group" do
+    before { board.save }
+    let!(:keep_sticky1) do
+      FactoryGirl.create(:sticky, board: board, group: "Keep")
+    end
+    let!(:keep_sticky2) do
+      FactoryGirl.create(:sticky, board: board, group: "Keep")
+    end
+    let!(:try_sticky) do
+      FactoryGirl.create(:sticky, board: board, group: "Try")
+    end
+
+    it "should include stickies in the group" do
+      expect(board.select_stickies("Keep").to_a).to include keep_sticky1, keep_sticky2
+    end
+    it "should not include stickies not in the group" do
+      expect(board.select_stickies("Keep").to_a).not_to include try_sticky
+    end
+  end
+
+  describe "select stickies by group in order" do
+    before { board.save }
+    let!(:like0_new_sticky) do
+      FactoryGirl.create(:sticky, board: board, like: 0, created_at: 1.hour.ago)
+    end
+    let!(:like0_old_sticky) do
+      FactoryGirl.create(:sticky, board: board, like: 0, created_at: 1.day.ago)
+    end
+    let!(:like3_new_sticky) do
+      FactoryGirl.create(:sticky, board: board, like: 3, created_at: 1.hour.ago)
+    end
+
+    it "should have the right stickies in the right order" do
+      expect(board.select_stickies("Keep").to_a).to eq [like3_new_sticky, like0_old_sticky, like0_new_sticky]
+    end
+  end
 end


### PR DESCRIPTION
ふせんの表示順を
1. Like の降順
2. Like 同数の場合、作成時刻の昇順（古い順）

にしました。
